### PR TITLE
[FIX] hr_holidays_public: provide defaults to process holidays

### DIFF
--- a/hr_holidays_public/__manifest__.py
+++ b/hr_holidays_public/__manifest__.py
@@ -14,7 +14,7 @@
     "Odoo Community Association (OCA),",
     "summary": "Manage Public Holidays",
     "website": "https://github.com/OCA/hr-holidays",
-    "depends": ["hr_holidays"],
+    "depends": ["hr_holidays", "hr_attendance"],
     "data": [
         "data/data.xml",
         "security/ir.model.access.csv",

--- a/hr_holidays_public/models/resource_calendar.py
+++ b/hr_holidays_public/models/resource_calendar.py
@@ -44,13 +44,17 @@ class ResourceCalendar(models.Model):
                         )
                         .mapped("date")
                     )
+        # even if employees and resource_country are empty
+        # we still process holidays, so provide defaults
         for resource in resources:
-            interval_resource = intervals[resource.id]
+            interval_resource = intervals.get(
+                resource.id, Intervals(self.env["hr.attendance"])
+            )
             attendances = []
-            country = resource_country[resource.id]
-            holidays = holidays_by_country[country]
+            country = resource_country.get(resource.id, self.env["res.country"])
+            holidays = holidays_by_country.get(country)
             for attendance in interval_resource._items:
-                if attendance[0].date() not in holidays:
+                if holidays and attendance[0].date() not in holidays:
                     attendances.append(attendance)
             intervals[resource.id] = Intervals(attendances)
         return intervals


### PR DESCRIPTION
On one of the projects, we encounter an empty recordset for employees, which can cause further mapping issues (KeyError) looking for the country