### PR TITLE
[FIX] hr_holidays_public: provide defaults to process holidays

### DIFF
--- a/hr_holidays_public/models/resource_calendar.py
+++ b/hr_holidays_public/models/resource_calendar.py
@@ -52,9 +52,9 @@ class ResourceCalendar(models.Model):
             )
             attendances = []
             country = resource_country.get(resource.id, self.env["res.country"])
-            holidays = holidays_by_country.get(country)
+            holidays = holidays_by_country.get(country, set())
             for attendance in interval_resource._items:
-                if holidays and attendance[0].date() not in holidays:
+                if attendance[0].date() not in holidays:
                     attendances.append(attendance)
             intervals[resource.id] = Intervals(attendances)
         return intervals


### PR DESCRIPTION
@gurneyalex I found a mistake in my previous code with defaults to provide the holidays process.
I didn't pay attention that holidays are provided as a set of public holidays, and was surprised that `True not in set()` results in True.
